### PR TITLE
Check only the pods belonging to the provided node. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 	"time"
 
 	kubeinformers "k8s.io/client-go/informers"
@@ -17,16 +18,29 @@ import (
 func main() {
 	klog.InitFlags(nil)
 
-	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	masterURL := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	metricsAddress := flag.String("metrics-listen-address", ":9091", "metrics server listen address.")
+	var config struct {
+		kubeconfig     string
+		masterURL      string
+		metricsAddress string
+		currentNode    string
+	}
 
+	flag.StringVar(&config.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&config.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&config.metricsAddress, "metrics-listen-address", ":9091", "metrics server listen address.")
 	flag.Parse()
+
+	config.currentNode = os.Getenv("NODE_NAME")
+	if config.currentNode == "" {
+		klog.Fatalf("NODE_NAME required environment variable not set")
+	}
+
+	klog.Info("Starting with config", config)
 
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromFlags(config.masterURL, config.kubeconfig)
 	if err != nil {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
@@ -38,10 +52,10 @@ func main() {
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 
-	ctrl := controller.New(kubeClient, kubeInformerFactory.Core().V1().Pods())
+	ctrl := controller.New(kubeClient, kubeInformerFactory.Core().V1().Pods(), config.currentNode)
 	kubeInformerFactory.Start(stopCh)
 
-	podmetrics.Serve(*metricsAddress, stopCh)
+	podmetrics.Serve(config.metricsAddress, stopCh)
 
 	if err = ctrl.Run(2, stopCh); err != nil {
 		klog.Fatalf("Error running controller: %s", err.Error())


### PR DESCRIPTION
The node is passed via an environment variable.
Also, dump the configuration when the process starts.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>