### PR TITLE
Add manifests to ship this as a daemonset and to integrate this with Prometheus.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.13 AS builder
+WORKDIR /go/src/github.com/openshift/network-metrics-daemon
+COPY . .
+RUN make build-bin
+
+FROM centos:7
+LABEL io.k8s.display-name="network-metrics-daemon" \
+    io.k8s.description="This is a daemon exposing network related metrics"
+COPY --from=builder /go/src/github.com/openshift/network-metrics-daemon/bin/network-metrics-daemon /usr/bin/network-metrics
+CMD ["/usr/bin/network-metrics"]
+

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,24 @@
+# This dockerfile is specific to building the network metrics daemon for OpenShift
+FROM openshift/origin-release:golang-1.13 as builder
+
+# Add everything
+ENV PKG_NAME=github.com/openshift/network-metrics-daemon
+ENV PKG_PATH=/go/src/$PKG_NAME
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $PKG_PATH
+
+RUN make build-bin
+
+WORKDIR /
+
+FROM openshift/origin-base
+COPY --from=builder /go/src/github.com/openshift/network-metrics-daemon/bin/network-metrics-daemon /usr/bin/network-metrics
+
+LABEL io.k8s.display-name="Network Metrics Daemon" \
+      io.k8s.description="This is a component of OpenShift Container Platform and provides a daemon that exposes admission controller for Multus CNI custom resources." \
+      io.openshift.tags="openshift" \
+      maintainer="Federico Paolinelli <fpaoline@redhat.com>"
+
+CMD ["/usr/bin/network-metrics"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 .PHONY: deps-update
 
+export DOCKERFILE?=Dockerfile
+export IMAGE_BASE?=quay.io/fpaoline/network-metrics-daemon
+export TAG?=latest
+export NAMESPACE?=openshift-network-metrics
+export MONITORING_NAMESPACE?=openshift-monitoring
+export KUBE_EXEC?=oc
+export IMAGE_TAG:=$(IMAGE_BASE):$(TAG)
+
+
 deps-update:
 	go mod tidy && \
 	go mod vendor
@@ -14,3 +23,13 @@ build-bin:
 
 unittests:
 	go test ./...
+
+image: ; $(info Building image...)
+	docker build -f $(DOCKERFILE) -t $(IMAGE_TAG) .
+
+image_push: ; $(info Building image...)
+	docker image push $(IMAGE_TAG)
+
+deploy:
+	hack/deploy.sh
+

--- a/deployments/01_namespace.yaml
+++ b/deployments/01_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: $NAMESPACE
+    openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "1"
+  name: $NAMESPACE

--- a/deployments/02_ds-roles.yaml
+++ b/deployments/02_ds-roles.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-daemon-sa
+  namespace: $NAMESPACE
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metrics-daemon-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["network-attachment-definitions"]
+    verbs: ["get", "watch", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metrics-daemon-sa-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: metrics-daemon-sa
+    apiGroup: ""
+    namespace: $NAMESPACE
+roleRef:
+  kind: ClusterRole
+  name: metrics-daemon-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deployments/03_daemonset.yaml
+++ b/deployments/03_daemonset.yaml
@@ -1,0 +1,44 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: network-metrics-daemon
+  namespace: $NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      app: network-metrics-daemon
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: network-metrics-daemon
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: network-metrics-daemon
+          image: $IMAGE_TAG
+          command:
+            - /usr/bin/network-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+          imagePullPolicy: Always
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      serviceAccountName: metrics-daemon-sa

--- a/deployments/04_prometheus.yaml
+++ b/deployments/04_prometheus.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: monitor-network
+  name: monitor-network
+  namespace: $NAMESPACE
+spec:
+  endpoints:
+    - interval: 10s
+      port: metrics
+      metricRelabelings:
+        - sourceLabels: [pod]
+          targetLabel: sourcepod
+        - sourceLabels: [namespace]
+          targetLabel: sourcenamespace
+        - sourceLabels: [metricspod]
+          targetLabel: pod
+        - sourceLabels: [metricsnamespace]
+          targetLabel: namespace
+  selector:
+    matchLabels:
+      service: network-metrics-service
+  namespaceSelector:
+    matchNames:
+      - $NAMESPACE
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    service: network-metrics-service
+  name: network-metrics-service
+  namespace: $NAMESPACE
+spec:
+  selector:
+    app: network-metrics-daemon
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: $NAMESPACE
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: $MONITORING_NAMESPACE

--- a/deployments/05_prometheus_rules.yaml
+++ b/deployments/05_prometheus_rules.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: network-metrics-with-network-name
+  namespace: $MONITORING_NAMESPACE
+  labels:
+    app: network-metrics
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: groupname
+      rules:
+        - record: container_network_receive_bytes_total_intf
+          expr: (container_network_receive_bytes_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_receive_errors_total_intf
+          expr: (container_network_receive_errors_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_receive_packets_total_intf
+          expr: (container_network_receive_packets_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_receive_packets_dropped_total_intf
+          expr: (container_network_receive_packets_dropped_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_transmit_bytes_total_intf
+          expr: (container_network_transmit_bytes_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_transmit_errors_total_intf
+          expr: (container_network_transmit_errors_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_transmit_packets_total_intf
+          expr: (container_network_transmit_packets_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: container_network_transmit_packets_dropped_total_intf
+          expr: (container_network_transmit_packets_dropped_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo $IMAGE_TAG
+
+for file in $(ls -v deployments/); do
+    echo "INFO - Applying file deployments/$file"
+    envsubst < deployments/${file} | ${KUBE_EXEC} apply -f -
+done;
+

--- a/pkg/podmetrics/podmetrics.go
+++ b/pkg/podmetrics/podmetrics.go
@@ -31,8 +31,8 @@ var (
 		prometheus.GaugeOpts{
 			Name: "network_attachment_definition_per_pod",
 			Help: "Metric to identify clusters with network attachment definition enabled instances.",
-		}, []string{"pod",
-			"namespace",
+		}, []string{"metricspod",
+			"metricsnamespace",
 			"interface",
 			"networkname"})
 )
@@ -47,10 +47,10 @@ func UpdateForPod(podName, namespace string, networks []podnetwork.Network) {
 		}
 
 		labels := prometheus.Labels{
-			"pod":         podName,
-			"namespace":   namespace,
-			"interface":   n.Interface,
-			"networkname": n.NetworkName,
+			"metricspod":       podName,
+			"metricsnamespace": namespace,
+			"interface":        n.Interface,
+			"networkname":      n.NetworkName,
 		}
 		NetAttachDefPerPod.With(labels).Add(0)
 	}
@@ -73,10 +73,10 @@ func DeleteAllForPod(podName, namespace string) {
 
 	for _, n := range nets {
 		labels := prometheus.Labels{
-			"pod":         podName,
-			"namespace":   namespace,
-			"interface":   n.Interface,
-			"networkname": n.NetworkName,
+			"metricspod":       podName,
+			"metricsnamespace": namespace,
+			"interface":        n.Interface,
+			"networkname":      n.NetworkName,
 		}
 		NetAttachDefPerPod.Delete(labels)
 	}
@@ -90,7 +90,6 @@ func Serve(metricsAddress string, stopCh <-chan struct{}) {
 	prometheus.Unregister(prometheus.NewGoCollector())
 
 	prometheus.MustRegister(NetAttachDefPerPod)
-
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 

--- a/pkg/podmetrics/podmetrics_test.go
+++ b/pkg/podmetrics/podmetrics_test.go
@@ -24,8 +24,8 @@ var podMetricsTests = []struct {
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",namespace="namespacename",networkname="firstNAD",pod="podname"} 0
-			network_attachment_definition_per_pod{interface="eth1",namespace="namespacename",networkname="firstNAD",pod="podname"} 0
+			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
+			network_attachment_definition_per_pod{interface="eth1",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
 			`,
 	},
 	{
@@ -38,8 +38,8 @@ var podMetricsTests = []struct {
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",namespace="namespacename",networkname="firstNAD",pod="podname"} 0
-			network_attachment_definition_per_pod{interface="eth1",namespace="namespacename",networkname="secondNAD",pod="podname"} 0
+			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
+			network_attachment_definition_per_pod{interface="eth1",metricsnamespace="namespacename",metricspod="podname",networkname="secondNAD"} 0
 			`,
 	},
 	{
@@ -71,7 +71,7 @@ var podMetricsTests = []struct {
 
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",namespace="namespacename",networkname="firstNAD",pod="podname2"} 0
+			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname2",networkname="firstNAD"} 0
 
 		`,
 	},


### PR DESCRIPTION
Provide the dockerfile for upstream building and for openshift building.
Add rules for building and pushing images.

I had to rename the metric labels in order to make the relabelling work. A following PR will adjust the name of the metrics / of the labels.

The image name, namespace and monitoring namespace are overrieadable to make this u/s friendly.