### PR TITLE
Rename the metrics & labels to be consistent with Prometheus guidelines (or try to)

### DIFF
--- a/deployments/04_prometheus.yaml
+++ b/deployments/04_prometheus.yaml
@@ -12,12 +12,12 @@ spec:
       port: metrics
       metricRelabelings:
         - sourceLabels: [pod]
-          targetLabel: sourcepod
+          targetLabel: __pod
         - sourceLabels: [namespace]
-          targetLabel: sourcenamespace
-        - sourceLabels: [metricspod]
+          targetLabel: __namespace
+        - sourceLabels: [source_pod]
           targetLabel: pod
-        - sourceLabels: [metricsnamespace]
+        - sourceLabels: [source_namespace]
           targetLabel: namespace
   selector:
     matchLabels:

--- a/deployments/05_prometheus_rules.yaml
+++ b/deployments/05_prometheus_rules.yaml
@@ -9,21 +9,21 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: groupname
+    - name: network_with_name
       rules:
-        - record: container_network_receive_bytes_total_intf
-          expr: (container_network_receive_bytes_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_receive_errors_total_intf
-          expr: (container_network_receive_errors_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_receive_packets_total_intf
-          expr: (container_network_receive_packets_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_receive_packets_dropped_total_intf
-          expr: (container_network_receive_packets_dropped_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_transmit_bytes_total_intf
-          expr: (container_network_transmit_bytes_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_transmit_errors_total_intf
-          expr: (container_network_transmit_errors_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_transmit_packets_total_intf
-          expr: (container_network_transmit_packets_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
-        - record: container_network_transmit_packets_dropped_total_intf
-          expr: (container_network_transmit_packets_dropped_total) + on(namespace,pod,interface) group_left(networkname) ( network_attachment_definition_per_pod )
+        - record: network:container_network_receive_bytes_total
+          expr: (container_network_receive_bytes_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_receive_errors_total
+          expr: (container_network_receive_errors_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_receive_packets_total
+          expr: (container_network_receive_packets_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_receive_packets_dropped_total
+          expr: (container_network_receive_packets_dropped_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_transmit_bytes_total
+          expr: (container_network_transmit_bytes_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_transmit_errors_total
+          expr: (container_network_transmit_errors_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_transmit_packets_total
+          expr: (container_network_transmit_packets_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )
+        - record: network:container_network_transmit_packets_dropped_total
+          expr: (container_network_transmit_packets_dropped_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )

--- a/pkg/podmetrics/podmetrics.go
+++ b/pkg/podmetrics/podmetrics.go
@@ -29,12 +29,12 @@ var (
 	// pod
 	NetAttachDefPerPod = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "network_attachment_definition_per_pod",
-			Help: "Metric to identify clusters with network attachment definition enabled instances.",
-		}, []string{"metricspod",
-			"metricsnamespace",
+			Name: "pod_network_name_info",
+			Help: "Metric to identify network names of networks added to pods.",
+		}, []string{"source_pod",
+			"source_namespace",
 			"interface",
-			"networkname"})
+			"network_name"})
 )
 
 //UpdateForPod adds metrics for all the provided networks to the given pod.
@@ -47,10 +47,10 @@ func UpdateForPod(podName, namespace string, networks []podnetwork.Network) {
 		}
 
 		labels := prometheus.Labels{
-			"metricspod":       podName,
-			"metricsnamespace": namespace,
+			"source_pod":       podName,
+			"source_namespace": namespace,
 			"interface":        n.Interface,
-			"networkname":      n.NetworkName,
+			"network_name":     n.NetworkName,
 		}
 		NetAttachDefPerPod.With(labels).Add(0)
 	}
@@ -73,10 +73,10 @@ func DeleteAllForPod(podName, namespace string) {
 
 	for _, n := range nets {
 		labels := prometheus.Labels{
-			"metricspod":       podName,
-			"metricsnamespace": namespace,
+			"source_pod":       podName,
+			"source_namespace": namespace,
 			"interface":        n.Interface,
-			"networkname":      n.NetworkName,
+			"network_name":     n.NetworkName,
 		}
 		NetAttachDefPerPod.Delete(labels)
 	}

--- a/pkg/podmetrics/podmetrics_test.go
+++ b/pkg/podmetrics/podmetrics_test.go
@@ -24,8 +24,8 @@ var podMetricsTests = []struct {
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
-			network_attachment_definition_per_pod{interface="eth1",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
+			pod_network_name_info{interface="eth0",network_name="firstNAD",source_namespace="namespacename",source_pod="podname"} 0
+			pod_network_name_info{interface="eth1",network_name="firstNAD",source_namespace="namespacename",source_pod="podname"} 0
 			`,
 	},
 	{
@@ -38,8 +38,8 @@ var podMetricsTests = []struct {
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname",networkname="firstNAD"} 0
-			network_attachment_definition_per_pod{interface="eth1",metricsnamespace="namespacename",metricspod="podname",networkname="secondNAD"} 0
+			pod_network_name_info{interface="eth0",network_name="firstNAD",source_namespace="namespacename",source_pod="podname"} 0
+			pod_network_name_info{interface="eth1",network_name="secondNAD",source_namespace="namespacename",source_pod="podname"} 0
 			`,
 	},
 	{
@@ -71,7 +71,7 @@ var podMetricsTests = []struct {
 
 		},
 		`
-			network_attachment_definition_per_pod{interface="eth0",metricsnamespace="namespacename",metricspod="podname2",networkname="firstNAD"} 0
+			pod_network_name_info{interface="eth0",network_name="firstNAD",source_namespace="namespacename",source_pod="podname2"} 0
 
 		`,
 	},
@@ -80,8 +80,8 @@ var podMetricsTests = []struct {
 func TestPodMetrics(t *testing.T) {
 
 	const metadata = `
-	# HELP network_attachment_definition_per_pod Metric to identify clusters with network attachment definition enabled instances.
-	# TYPE network_attachment_definition_per_pod gauge
+	# HELP pod_network_name_info Metric to identify network names of networks added to pods.
+	# TYPE pod_network_name_info gauge
 	`
 
 	for _, tst := range podMetricsTests {


### PR DESCRIPTION
This PR tries to make the labelling convention more near to Prometheus conventions.

Links:
https://prometheus.io/docs/practices/rules/
https://prometheus.io/docs/practices/naming/