### PR TITLE
Align the docs / unit tests with the new naming convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# network-metrics-daemon
-network-metrics-daemon is a daemon component that collects and publishes network related metrics
+# Network Metrics Daemon
+
+Network Metrics Daemon is a daemon component that collects and publishes network related metrics
 
 ## Rationale
 
@@ -32,8 +33,10 @@ This is addressed by introducing the new `pod_network_name_info` described in th
 This daemonset publishes a `pod_network_name_info` gauge metric, with a fixed value of 0:
 
 ```
-pod_network_name_info{interface="net0",namespace="namespacename",network_name="firstNAD",pod="podname"} 0
+pod_network_name_info{interface="net0",namespace="namespacename",network_name="nadnamespace/firstNAD",pod="podname"} 0
 ```
+
+The network name label is produced using the annotation added by multus. It's the concatenation of the namespace the `network attachment definition` belongs to, plus the name of the `network attachment definition`.
 
 The new metric alone does not provide much value, but combined with the container_network_* metrics mentioned above, it offers a better support for monitoring secondary networks.
 

--- a/pkg/podmetrics/podmetrics_test.go
+++ b/pkg/podmetrics/podmetrics_test.go
@@ -18,36 +18,36 @@ var podMetricsTests = []struct {
 		"twonetworks same network name",
 		func() {
 			networks := []podnetwork.Network{
-				{"eth0", "firstNAD"},
-				{"eth1", "firstNAD"},
+				{"eth0", "namespace1/firstNAD"},
+				{"eth1", "namespace1/firstNAD"},
 			}
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="firstNAD",pod="podname"} 0
-			pod_network_name_info{interface="eth1",namespace="namespacename",network_name="firstNAD",pod="podname"} 0
+			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="namespace1/firstNAD",pod="podname"} 0
+			pod_network_name_info{interface="eth1",namespace="namespacename",network_name="namespace1/firstNAD",pod="podname"} 0
 			`,
 	},
 	{
 		"twonetworks different networkname",
 		func() {
 			networks := []podnetwork.Network{
-				{"eth0", "firstNAD"},
-				{"eth1", "secondNAD"},
+				{"eth0", "namespace1/firstNAD"},
+				{"eth1", "namespace2/secondNAD"},
 			}
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 		},
 		`
-			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="firstNAD",pod="podname"} 0
-			pod_network_name_info{interface="eth1",namespace="namespacename",network_name="secondNAD",pod="podname"} 0
+			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="namespace1/firstNAD",pod="podname"} 0
+			pod_network_name_info{interface="eth1",namespace="namespacename",network_name="namespace2/secondNAD",pod="podname"} 0
 			`,
 	},
 	{
 		"add and delete",
 		func() {
 			networks := []podnetwork.Network{
-				{"eth0", "firstNAD"},
-				{"eth1", "secondNAD"},
+				{"eth0", "namespace1/firstNAD"},
+				{"eth1", "namespace2/secondNAD"},
 			}
 			podmetrics.UpdateForPod("podname", "namespacename", networks)
 			podmetrics.DeleteAllForPod("podname", "namespacename")
@@ -59,11 +59,11 @@ var podMetricsTests = []struct {
 		"two pods and delete one",
 		func() {
 			networks := []podnetwork.Network{
-				{"eth0", "firstNAD"},
-				{"eth1", "secondNAD"},
+				{"eth0", "namespace1/firstNAD"},
+				{"eth1", "namespace2/secondNAD"},
 			}
 			networks2 := []podnetwork.Network{
-				{"eth0", "firstNAD"},
+				{"eth0", "namespace1/firstNAD"},
 			}
 			podmetrics.UpdateForPod("podname1", "namespacename", networks)
 			podmetrics.UpdateForPod("podname2", "namespacename", networks2)
@@ -71,7 +71,7 @@ var podMetricsTests = []struct {
 
 		},
 		`
-			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="firstNAD",pod="podname2"} 0
+			pod_network_name_info{interface="eth0",namespace="namespacename",network_name="namespace1/firstNAD",pod="podname2"} 0
 
 		`,
 	},

--- a/pkg/podnetwork/pod_test.go
+++ b/pkg/podnetwork/pod_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const simpleNetworkAnnotation = `[{
-	"name": "kindnet",
+	"name": "default/kindnet",
 	"interface": "eth0",
 	"ips": [
 		"10.244.0.10"
@@ -21,7 +21,7 @@ const simpleNetworkAnnotation = `[{
 }]`
 
 const multipleNetworkAnnotation = `[{
-	"name": "kindnet",
+	"name": "default/kindnet",
 	"interface": "eth0",
 	"ips": [
 		"10.244.0.10"
@@ -30,7 +30,7 @@ const multipleNetworkAnnotation = `[{
 	"default": true,
 	"dns": {}
 },{
-	"name": "macvlan-conf",
+	"name": "namespace1/macvlan-conf",
 	"interface": "net1",
 	"ips": [
 		"192.168.1.200"
@@ -59,7 +59,7 @@ var podNetworkTests = []struct {
 		[]podnetwork.Network{
 			podnetwork.Network{
 				Interface:   "eth0",
-				NetworkName: "kindnet",
+				NetworkName: "default/kindnet",
 			},
 		},
 	},
@@ -76,11 +76,11 @@ var podNetworkTests = []struct {
 		[]podnetwork.Network{
 			podnetwork.Network{
 				Interface:   "eth0",
-				NetworkName: "kindnet",
+				NetworkName: "default/kindnet",
 			},
 			podnetwork.Network{
 				Interface:   "net1",
-				NetworkName: "macvlan-conf",
+				NetworkName: "namespace1/macvlan-conf",
 			},
 		},
 	},


### PR DESCRIPTION
With https://github.com/openshift/multus-cni/commit/e7c8977423a6c221074f173a497a5de0aaa98649,
the way the name is added to the pod annotation is changed, from NAD name to namespace/NAD name.

Here we update the doc and unit tests to reflect that.