### PR TITLE
Updating ose-network-metrics-daemon builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is specific to building the network metrics daemon for OpenShift
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 # Add everything
 ENV PKG_NAME=github.com/openshift/network-metrics-daemon
@@ -13,7 +13,7 @@ RUN make build-bin
 
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/openshift/network-metrics-daemon/bin/network-metrics-daemon /usr/bin/network-metrics
 
 LABEL io.k8s.display-name="Network Metrics Daemon" \


### PR DESCRIPTION
Updating ose-network-metrics-daemon builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-network-metrics-daemon.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.