### PR TITLE
deployments: Use 33% as the rollout maxUnavailable

### DIFF
--- a/deployments/03_daemonset.yaml
+++ b/deployments/03_daemonset.yaml
@@ -10,6 +10,8 @@ spec:
       app: network-metrics-daemon
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       labels:


### PR DESCRIPTION
network-metrics-daemon has no impact on availability of the cluster,
but should rollout no more than one third of all pods at a time so
that an upgrade doesn't completely remove the function.

Consistent with direction expressed in https://github.com/openshift/origin/pull/25928