### PR TITLE
Adjusted test ns for the new ocp security model

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -43,6 +43,12 @@ var _ = ginkgo.BeforeSuite(func() {
 	nameSpace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: consts.TestingNamespace,
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/audit":               "privileged",
+				"pod-security.kubernetes.io/enforce":             "privileged",
+				"pod-security.kubernetes.io/warn":                "privileged",
+				"security.openshift.io/scc.podSecurityLabelSync": "false",
+			},
 		},
 	}
 	_, err := client.Client.Namespaces().Create(context.Background(), nameSpace, metav1.CreateOptions{})


### PR DESCRIPTION
Added privileged labels to the test namespace in order to allow to run test privileged pods. These labels are required in ocp 4.12