### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS builder
+FROM golang:1.20 AS builder
 WORKDIR /go/src/github.com/openshift/network-metrics-daemon
 COPY . .
 RUN make build-bin


### PR DESCRIPTION
Upgrade the docker image for golang to be the same as for OpenShift build.
Otherwise I got this error:

```
 => ERROR [builder 4/4] RUN make build-bin                                                                      3.9s
------
 > [builder 4/4] RUN make build-bin:
#0 0.125 go build --mod=vendor -ldflags "-X main.build=$(git rev-parse HEAD)" -o bin/network-metrics-daemon
#0 1.486 # golang.org/x/net/http2
#0 1.486 vendor/golang.org/x/net/http2/transport.go:416:45: undefined: os.ErrDeadlineExceeded
#0 3.827 make: *** [Makefile:23: build-bin] Error 2
```