### PR TITLE
Update command list to apply NODE_NAME env var correctly

### DIFF
--- a/deployments-k8s/03_daemonset.yaml
+++ b/deployments-k8s/03_daemonset.yaml
@@ -23,8 +23,9 @@ spec:
         - name: network-metrics-daemon
           image: $IMAGE_TAG
           command:
-            - /usr/bin/network-metrics
-          args: ["--node-name", "${DOLLAR}(NODE_NAME)"]
+            - "bash"
+            - "-c"
+            - "/usr/bin/network-metrics --node-name ${NODE_NAME}"
           resources:
             requests:
               cpu: 10m

--- a/deployments/03_daemonset.yaml
+++ b/deployments/03_daemonset.yaml
@@ -26,8 +26,9 @@ spec:
         - name: network-metrics-daemon
           image: $IMAGE_TAG
           command:
-            - /usr/bin/network-metrics
-          args: ["--node-name", "${DOLLAR}(NODE_NAME)"]
+            - "bash"
+            - "-c"
+            - "/usr/bin/network-metrics --node-name ${NODE_NAME}"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
We had an issue when deploying the daemon set and found the `NODE_NAME` was not translated correctly through args. Consequently the network-metrics-daemon pods was unable to properly execute as the environment variable was nullified.

By utilizing a different command method, the pod is now able to retrieve the `NODE_NAME` env variable.

Running on 8 nodes, version `v1.29.4+rke2r1`.