### PR TITLE
CORENET-7238: Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,36 @@
 reviewers:
-- zshi-redhat
-- fedepaol
-- SchSeba
-- dougbtv
-- bpickard22
-- pliurh
+  - fedepaol
+  - SchSeba
+  - bpickard22
+  - anuragthehatter
+  - arkadeepsen
+  - arghosh93
+  - asood-rh
+  - danwinship
+  - jcaamano
+  - jluhrsen
+  - jechen0648
+  - LionelJouin
+  - martinkennelly
+  - marty-power
+  - mattedallo
+  - miheer
+  - kyrtapz
+  - pperiyasamy
+  - raphaelvrosa
+  - SachinNinganure
+  - shreyasbe
+  - tssurya
+  - taanyas
+  - vinnie1110
+  - weliang1
+  - wizhaoredhat
 approvers:
-- zshi-redhat
-- fedepaol
-- SchSeba
-- dougbtv
-- bpickard22
-- pliurh
+  - fedepaol
+  - SchSeba
+  - bpickard22
+  - LionelJouin
+  - danwinship
+  - wizhaoredhat
 component: "Networking"
 subcomponent: "multus"


### PR DESCRIPTION
Update OWNERS file - remove inactive and non-Red Hat members, add full corenetworking team as reviewers and updated approvers.

Removed: zshi-redhat, dougbtv, pliurh
Added reviewers: full corenetworking team
Added approvers: LionelJouin, danwinship, SchSeba, wizhaoredhat, bpickard22, fedepaol

Jira: https://issues.redhat.com/browse/CORENET-7238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer and approver assignments for the Networking/multus component.
  * Added the current designated reviewers and approvers and removed outdated assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->