### PR TITLE
export BIN_DIR to PATH so golint is found on Go 1.22 builder

### DIFF
--- a/hack/check_golint.sh
+++ b/hack/check_golint.sh
@@ -4,4 +4,5 @@
 # Run the linter on everything except generated code
 set -euo pipefail
 
+export PATH="$(pwd)/bin:${PATH}"
 golint -set_exit_status $(go list ./... | grep -v '/vendor')

--- a/hack/get_tools.sh
+++ b/hack/get_tools.sh
@@ -6,5 +6,6 @@ set -xeuo pipefail
 export CURPATH=`pwd`
 export BIN_DIR=$CURPATH/bin
 export GO111MODULE=on
+export PATH="${BIN_DIR}:${PATH}"
 
-GOBIN=${BIN_DIR} go install -mod=mod golang.org/x/lint/golint@latest
+GOBIN=${BIN_DIR} go install golang.org/x/lint/golint@latest

--- a/hack/get_tools.sh
+++ b/hack/get_tools.sh
@@ -8,4 +8,4 @@ export BIN_DIR=$CURPATH/bin
 export GO111MODULE=on
 export PATH="${BIN_DIR}:${PATH}"
 
-GOBIN=${BIN_DIR} go install golang.org/x/lint/golint@latest
+go build -o ${BIN_DIR}/golint golang.org/x/lint/golint


### PR DESCRIPTION
The get_tools.sh installs golint into BIN_DIR via GOBIN, but check_golint.sh invokes it as a bare command. On the Go 1.22
builder (release-4.18) BIN_DIR is not in PATH, causing 'golint: command not found'. Exporting PATH fixes this consistently across all Go versions.